### PR TITLE
Added support for DICE and workaround for pycairo if not able to produce

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,13 +61,26 @@ because of some error, it's likely to be one of the following
 problems:
 
 * The header files for the python distribution are not installed. Look
-  up `python-dev` or `python3.4-dev`
-
-* You need to compile the C code from source: download it
-[here](http://igraph.org/) and follow the instructions. In general you
-should only need to follow the standard procedure:
+  up `build-essential`, and `python-dev` or `python3.4-dev`
 
 ```bash
+# in a new terminal:
+$ sudo apt-get install python-dev python3.4-dev
+$ sudo apt-get install build-essential
+```
+
+* You need to compile the C code from source: download it
+[here](http://igraph.org/c) and follow the instructions. In general you
+should only need to follow the standard procedure:
+
+``` bash
+$ sudo apt-get install libxml2-dev
+# dwnload the c binary and extract.
+$ wget http://igraph.org/nightly/get/c/igraph-0.7.1.tar.gz
+$ tar xvf igraph-0.7.1.tar.gz
+$ cd igraph-0.7.1
+
+# Installation of c binary
 $ ./configure
 $ make
 $ make install
@@ -75,19 +88,26 @@ $ make install
 
 #### Install pycairo
 
-On Ubuntu, check this [package](http://packages.ubuntu.com/search?keywords=python-cairo).
+On Ubuntu, check this [package](http://packages.ubuntu.com/search?keywords=python-cairo).<br>
+_By default this will install the package into `python` (which may not be `python3.4`)_ <br>
+_(TODO: will this still work??))_
 
 If you are using a virtualenv or you don't use Ubuntu, do the following:
 
-* Download and extract the pycairo package in the virtualenv
+* Download and extract the `pycairo` package _in_ the virtualenv
 
 ```bash
 $ curl http://cairographics.org/releases/pycairo-1.10.0.tar.bz2 -O
 $ tar xvf pycairo-1.10.0.tar.bz2
+# That doesnt quite work for me, but these do:
+# wget https://www.cairographics.org/releases/pycairo-1.10.0.tar.bz2
+# bunzip2 pycairo-1.10.0.tar.bz2
+# tar xvf pycairo-1.10.0.tar
 $ cd pycairo-1.10.0/
+$ ./waf configure # will fail, but need to generate the hidden .waf folder first for below
 ```
 
-* edit a file in the hidden .waf folder that the extraction has created (e.g. `./.waf-1.6.4-e3c1e08604b18a10567cfcd2d02eb6e6`. To do this, go into the folder and edit `./.waf-1.6.4-somenumbers/waflib/Tools/python.py` to call the python3.4-config directly.
+* edit a file in the hidden .waf folder that the extraction has created (e.g. `./.waf-1.6.4-e3c1e08604b18a10567cfcd2d02eb6e6`. To do this, go into the folder and edit `./.waf-1.6.4-somenumbers/waflib/Tools/python.py` and replace the following line (see -/+ in codeblock below) to call the python3.4-config directly.
 ```diff
     --- waflib/Tools/python.py.old  2014-08-01 14:36:23.750613874 +0000
     +++ waflib/Tools/python.py      2014-08-01 14:36:38.359627761 +0000
@@ -127,7 +147,7 @@ $ make html
 #### Test the software
 
 ```bash
-$ cd ../src # relative root is carneades/
+$ cd ../src/carneades # relative root is carneades/
 $ python -i caes.py
 ```
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ This is a pedagogically-oriented attempt to implement aspects of the [Carneades 
 
 ### Quick Link:
 Documentation for setting up:
-1. [on DICE machine](#setting-up-on-DICE)
-2. [on your own machine](#installing-carneades-on-your-own-computer)
+1. [on DICE machine](#setting-it-up-on-DICE)
+2. [on your own machine](#installation-on-your-own-computer)
 The main difference between them is the creation of python virtual environment.
 
 ### Requirements
@@ -30,7 +30,7 @@ S1987654: pyvenv ailp_env # create an python3.4 environment in the folder 'ailp_
 Activate the python environment (you have to activate the environment everytime before you run Carneades):
 ```
 S1987654: source ailp_env/bin/activate
-# Once the environment is activate, you should see it the name of the environment beside it:
+# Once the environment is activate, you should see the name of the environment beside it:
 (ailp_env) S1987654:
 ```
 
@@ -39,7 +39,7 @@ Similar to installing on your own computer, you need to install the libraries re
 
 
 
-### Installation on your own computer
+## Installation on your own computer
 
 #### Install `python3.4` (via apt, homebrew or your favourite package_system)
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,15 @@
 
 This is a pedagogically-oriented attempt to implement aspects of the [Carneades Argument Evaluation framework](http://carneades.github.io/carneades/Carneades/). It closely follows the Haskell implementation in the [CarneadesDSL package](https://hackage.haskell.org/package/CarneadesDSL).
 
-The libraries needed to run this code on DICE are already available (except that the plotting functionality is currently not supported). Just remember that you need to explicitly call `python3.4` since the `python` command on DICE defaults to `python2.7`. So if you are happy to work on DICE, you are ready to go. :smile:
+<!-- The libraries needed to run this code on DICE are already available (except that the plotting functionality is currently not supported). Just remember that you need to explicitly call `python3.4` since the `python` command on DICE defaults to `python2.7`. So if you are happy to work on DICE, you are ready to go. :smile: -->
 
-If you want to install the necessary libraries on your own machine, however, read on.
 
-## Installing the libraries for the Carneades sample code on your own computer
+
+### Quick Link:
+Documentation for setting up:
+1. [on DICE machine](#setting-up-on-DICE)
+2. [on your own machine](#installing-carneades-on-your-own-computer)
+The main difference between them is the creation of python virtual environment.
 
 ### Requirements
 
@@ -17,7 +21,25 @@ If you want to install the necessary libraries on your own machine, however, rea
 - Sphinx (docs only)
 - Basicstrap theme for sphinx (docs only)
 
-### Installation
+## Setting it up on DICE
+###Creating python virtual environment
+Create a python3.4 virtual environment:
+```$
+S1987654: pyvenv ailp_env # create an python3.4 environment in the folder 'ailp_env'
+```
+Activate the python environment (you have to activate the environment everytime before you run Carneades):
+```
+S1987654: source ailp_env/bin/activate
+# Once the environment is activate, you should see it the name of the environment beside it:
+(ailp_env) S1987654:
+```
+
+### Installing libraries:
+Similar to installing on your own computer, you need to install the libraries required. However, there is no need to set up the virutal environment again. I.e. follow the instructions from [installing sphinx](#install-sphinx-and-basicstrap) to [installing pycairo](#install-pycairo)
+
+
+
+### Installation on your own computer
 
 #### Install `python3.4` (via apt, homebrew or your favourite package_system)
 
@@ -71,9 +93,7 @@ $ sudo ldconfig # this does some magic!
 
 #### Install pycairo
 
-On Ubuntu, check this [package](http://packages.ubuntu.com/search?keywords=python-cairo).<br>
-_By default this will install the package into `python` (which may not be `python3.4`)_<br>
-_(TODO: will this still work??))_
+On Ubuntu, check this [package](http://packages.ubuntu.com/search?keywords=python-cairo).
 
 If you are using a virtualenv or you don't use Ubuntu, do the following:
 
@@ -190,19 +210,17 @@ Now follow the rest of the installation.
 
 ### Work around for `pycairo` and `igraph`
 
-For output where the graphs are not shown (such as on DICE), a workaround to produce the graph. Thanks to the `write_to_graphviz` method, a `.dot` file will be produced whenever you run `caes.py`. This `.dot` file can then be visualised using a Graphiviz viewer, such as:
+For output where the graphs are not shown, here is a workaround to produce the graph. Thanks to the `write_to_graphviz` method, a `.dot` file will be produced whenever you run `caes.py`. This `.dot` file can then be visualised using a Graphiviz viewer, such as:
 
 - <http://www.webgraphviz.com/>
 - <http://sandbox.kidstrythisathome.com/erdos/>
 - <http://dreampuf.github.io/GraphvizOnline/>
 
-The `.dot` file is by default `graph.dot`. It will be good to rename each caes example with a different filename to prevent it being overwritten in future iteration of `caes.py`.
+The `.dot` file is by default `graph.dot`. It will be good to rename each caes example with a different filename to prevent it being overwritten in future iterations of `caes.py`.
 
 ```bash
 # In caes.py, e.g. in def arg_demo(), change the following line to define the filename
 >> argset.draw()
 >> argset.write_to_graphviz(<filename>.dot)
 ```
-The `<filename>.dot` file will be found adjacent to the `caes.py` file. (defaul in `$PATH_TO_/carneades/src/carneades`).
-
-TODO: more work to be done to verify if there's a work around using `pycairo` or `igraph`. For now, these packages are still required.
+The `<filename>.dot` file will be found adjacent to the `caes.py` file. (defaul in `$PATH_TO_CARNEADES/carneades/src/carneades`).

--- a/README.md
+++ b/README.md
@@ -1,40 +1,27 @@
 # Carneades sample code
 
-This is a pedagogically-oriented attempt to implement aspects of the
-[Carneades Argument Evaluation
-framework](http://carneades.github.io/carneades/Carneades/). It
-closely follows the Haskell implementation in the [CarneadesDSL
-package](https://hackage.haskell.org/package/CarneadesDSL).
+This is a pedagogically-oriented attempt to implement aspects of the [Carneades Argument Evaluation framework](http://carneades.github.io/carneades/Carneades/). It closely follows the Haskell implementation in the [CarneadesDSL package](https://hackage.haskell.org/package/CarneadesDSL).
 
-The libraries needed to run this code on DICE are already available
-(except that the plotting functionality is currently not supported).
-Just remember that you need to explicitly call ``python3.4`` since the
-``python`` command on DICE defaults to ``python2.7``. So if you are
-happy to work on DICE, you are ready to go. :smile:
+The libraries needed to run this code on DICE are already available (except that the plotting functionality is currently not supported). Just remember that you need to explicitly call `python3.4` since the `python` command on DICE defaults to `python2.7`. So if you are happy to work on DICE, you are ready to go. :smile:
 
-
-
-If you want to install the necessary libraries on your own machine,
-however, read on.
+If you want to install the necessary libraries on your own machine, however, read on.
 
 ## Installing the libraries for the Carneades sample code on your own computer
 
 ### Requirements
 
-* Python3.4
-* igraph
-* pycairo (for igraph)
-* Virtualenv (Optional)
-* Sphinx (docs only)
-* Basicstrap theme for sphinx (docs only)
+- Python3.4
+- igraph
+- pycairo (for igraph)
+- Virtualenv (Optional)
+- Sphinx (docs only)
+- Basicstrap theme for sphinx (docs only)
 
 ### Installation
 
 #### Install `python3.4` (via apt, homebrew or your favourite package_system)
 
-Note for Linux users (especially Ubuntu 12.04 users): follow this
-[link](#install-python34) to have more info about installing the
-python distro.
+Note for Linux users (especially Ubuntu 12.04 users): follow this [link](#install-python34) to have more info about installing the python distro.
 
 #### Create a virtualenv:
 
@@ -56,12 +43,9 @@ $ pip install sphinxjp.themes.basicstrap
 $ pip install python-igraph
 ```
 
-This should also install the C bindings. If that doesn't happen
-because of some error, it's likely to be one of the following
-problems:
+This should also install the C bindings. If that doesn't happen because of some error, it's likely to be one of the following problems:
 
-* The header files for the python distribution are not installed. Look
-  up `build-essential`, and `python-dev` or `python3.4-dev`
+- The header files for the python distribution are not installed. Look up `build-essential`, and `python-dev` or `python3.4-dev`
 
 ```bash
 # in a new terminal:
@@ -69,9 +53,9 @@ $ sudo apt-get install python-dev python3.4-dev
 $ sudo apt-get install build-essential
 ```
 
-* To install the C bindings:
+- To install the C bindings:
 
-``` bash
+```bash
 $ sudo apt-get install libxml2-dev
 # download the igraph c bindings and extract.
 $ wget http://igraph.org/nightly/get/c/igraph-0.7.1.tar.gz
@@ -88,12 +72,12 @@ $ sudo ldconfig # this does some magic!
 #### Install pycairo
 
 On Ubuntu, check this [package](http://packages.ubuntu.com/search?keywords=python-cairo).<br>
-_By default this will install the package into `python` (which may not be `python3.4`)_ <br>
+_By default this will install the package into `python` (which may not be `python3.4`)_<br>
 _(TODO: will this still work??))_
 
 If you are using a virtualenv or you don't use Ubuntu, do the following:
 
-* Download and extract the `pycairo` package _in_ the virtualenv
+- Download and extract the `pycairo` package _in_ the virtualenv
 
 ```bash
 $ wget https://www.cairographics.org/releases/pycairo-1.10.0.tar.bz2
@@ -103,9 +87,10 @@ $ cd pycairo-1.10.0/
 $ ./waf configure # This will fail, but need to generate the hidden .waf folder first for below
 ```
 
-* edit a file in the hidden .waf folder that the extraction has created (e.g. `./.waf-1.6.4-e3c1e08604b18a10567cfcd2d02eb6e6`. To do this, go into the folder and edit `./.waf-1.6.4-somenumbers/waflib/Tools/python.py` and replace the following line (see -/+ in codeblock below) to call the python3.4-config directly.
-```diff
-    --- waflib/Tools/python.py.old  2014-08-01 14:36:23.750613874 +0000
+- edit a file in the hidden .waf folder that the extraction has created (e.g. `./.waf-1.6.4-e3c1e08604b18a10567cfcd2d02eb6e6`. To do this, go into the folder and edit `./.waf-1.6.4-somenumbers/waflib/Tools/python.py` and replace the following line (see -/+ in codeblock below) to call the python3.4-config directly.
+
+  ```diff
+  --- waflib/Tools/python.py.old  2014-08-01 14:36:23.750613874 +0000
     +++ waflib/Tools/python.py      2014-08-01 14:36:38.359627761 +0000
     @@ -169,7 +169,7 @@
                     conf.find_program('python-config-%s'%num,var='PYTHON_CONFIG',mandatory=False)
@@ -116,19 +101,20 @@ $ ./waf configure # This will fail, but need to generate the hidden .waf folder 
                             if(incstr.startswith('-I')or incstr.startswith('/I')):
                                     incstr=incstr[2:]
                             if incstr not in includes:
-```
+  ```
 
-* compile and install the package
+- compile and install the package
 
 ```bash
 $ ./waf configure --prefix=$VIRTUAL_ENV
 $ ./waf build
 $ ./waf install
 ```
-* If you run into 'cairo >= 1.10.0' error, you will need to install `cairo` and `pixman`:
 
+- If you run into 'cairo >= 1.10.0' error, you will need to install `cairo` and `pixman`:
 
 Download and Install `pixman`
+
 ```bash
 # Open a new terminal and run these commands:
 $ wget https://www.cairographics.org/releases/pixman-0.34.0.tar.gz
@@ -142,6 +128,7 @@ $ make install
 ```
 
 Download and Install `cairo`
+
 ```bash
 # continuing from above:
 $ cd ..
@@ -156,7 +143,6 @@ $ make install
 ```
 
 You should now have both `cairo` and `pixman` installed in your machine. Return to installation for pycairo[link](#install-pycairo).
-
 
 ### Clone repository
 
@@ -181,20 +167,13 @@ $ python -i caes.py
 
 ### Install python3.4
 
-(Linux users)
--------------
+## (Linux users)
 
-The following is to install python3.4 on Ubuntu 12.04 LTS. Other
-distributions should do more or less the same. If you have a newer
-installation of Ubuntu or derivatives, you can probably skip some
-passages.
+The following is to install python3.4 on Ubuntu 12.04 LTS. Other distributions should do more or less the same. If you have a newer installation of Ubuntu or derivatives, you can probably skip some passages.
 
-*WARNING: Although unlikely, this might break your python2 installation,
-so do it at your own risk or set up a VM*
+_WARNING: Although unlikely, this might break your python2 installation, so do it at your own risk or set up a VM_
 
-Unless you want to build from source (In which case, kudos!), add
-[this PPA](https://launchpad.net/~fkrull/+archive/ubuntu/deadsnakes)
-to your apt source list:
+Unless you want to build from source (In which case, kudos!), add [this PPA](https://launchpad.net/~fkrull/+archive/ubuntu/deadsnakes) to your apt source list:
 
 ```bash
 $ add-apt-repository ppa:fkrull/deadsnakes
@@ -208,3 +187,22 @@ $ apt-get install python3.4 python3.4-dev
 ```
 
 Now follow the rest of the installation.
+
+### Work around for `pycairo` and `igraph`
+
+For output where the graphs are not shown (such as on DICE), a workaround to produce the graph. Thanks to the `write_to_graphviz` method, a `.dot` file will be produced whenever you run `caes.py`. This `.dot` file can then be visualised using a Graphiviz viewer, such as:
+
+- <http://www.webgraphviz.com/>
+- <http://sandbox.kidstrythisathome.com/erdos/>
+- <http://dreampuf.github.io/GraphvizOnline/>
+
+The `.dot` file is by default `graph.dot`. It will be good to rename each caes example with a different filename to prevent it being overwritten in future iteration of `caes.py`.
+
+```bash
+# In caes.py, e.g. in def arg_demo(), change the following line to define the filename
+>> argset.draw()
+>> argset.write_to_graphviz(<filename>.dot)
+```
+The `<filename>.dot` file will be found adjacent to the `caes.py` file. (defaul in `$PATH_TO_/carneades/src/carneades`).
+
+TODO: more work to be done to verify if there's a work around using `pycairo` or `igraph`. For now, these packages are still required.


### PR DESCRIPTION
On DICE, a simple work around is by using pvenv and then follow the instructions similar to setting up on your own machine.